### PR TITLE
Add option --disable-server-density

### DIFF
--- a/openmetrics_udpserver/src/config.rs
+++ b/openmetrics_udpserver/src/config.rs
@@ -3,4 +3,5 @@ pub struct Config {
     pub debug: bool,
     pub udp_bind: String,
     pub http_bind: String,
+    pub disable_server_density: bool,
 }

--- a/openmetrics_udpserver/src/config.rs
+++ b/openmetrics_udpserver/src/config.rs
@@ -3,5 +3,5 @@ pub struct Config {
     pub debug: bool,
     pub udp_bind: String,
     pub http_bind: String,
-    pub disable_server_density: bool,
+    pub disable_serverdensity: bool,
 }

--- a/openmetrics_udpserver/src/http_server.rs
+++ b/openmetrics_udpserver/src/http_server.rs
@@ -41,7 +41,7 @@ async fn get_metrics(
 }
 
 pub(crate) fn bind(
-    config: Config,
+    config: &Config,
     metric_registry: Arc<RwLock<Registry>>,
 ) -> JoinHandle<Result<(), hyper::Error>> {
     let state = Arc::new(HttpServerState { metric_registry });

--- a/openmetrics_udpserver/src/serverdensity/aggregator.rs
+++ b/openmetrics_udpserver/src/serverdensity/aggregator.rs
@@ -21,8 +21,11 @@ pub struct ServerDensityConfig {
 
 impl ServerDensityConfig {
     pub fn from_args(matches: ArgMatches) -> Self {
+        let token_option = matches.get_one::<String>("token");
+        if token_option.is_none() { panic!("'--token' has to be provided, if server density is not disabled with '--disable-server-density'"); }
+
         let mut base_config = ServerDensityConfig {
-            token: matches.get_one::<String>("token").unwrap().to_string(),
+            token: token_option.unwrap().to_string(),
             account_url: matches
                 .get_one::<String>("account-url")
                 .unwrap_or(&"".to_string())


### PR DESCRIPTION
The udp agent has two ways to transport metrics to a monitoring service:
* via push to Serverdensity
* via OpenMetrics (pull) to Prometheus

This PR makes Serverdensity optional. It can be deactivated with the flag --disable-server-density. Then only OpenMetrics are provided on the /metrics endpoint on the http port.