### PR TITLE
Use Prometheus type "gauge" for non-counter metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic_float"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62af46d040ba9df09edc6528dae9d8e49f5f3e82f55b7d2ec31a733c38dbc49d"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +616,7 @@ name = "openmetrics_udpserver"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "atomic_float",
  "axum",
  "byteorder",
  "bytes",

--- a/openmetrics_udpserver/Cargo.toml
+++ b/openmetrics_udpserver/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "*"
+atomic_float = "0.1.0"
 clap = "4.4.*"
 bytes = "1.5.*"
 regex = "1.10.*"

--- a/openmetrics_udpserver/src/metrics/resetting_value_metric.rs
+++ b/openmetrics_udpserver/src/metrics/resetting_value_metric.rs
@@ -1,5 +1,6 @@
 use std::fmt::Error;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
+use atomic_float::AtomicF64;
 use std::sync::Arc;
 
 use crate::metrics::ModifyMetric;
@@ -8,13 +9,13 @@ use prometheus_client::metrics::{MetricType, TypedMetric};
 
 #[derive(Debug, Default, Clone)]
 pub struct ResettingSingleValMetric {
-    val: Arc<AtomicU64>,
+    val: Arc<AtomicF64>,
 }
 
 impl ModifyMetric for ResettingSingleValMetric {
     fn observe(&self, value: i32) {
-        if let Ok(val_as_u64) = u64::try_from(value) {
-            self.val.store(val_as_u64, Ordering::Relaxed);
+        if let Ok(val_as_f64) = f64::try_from(value) {
+            self.val.store(val_as_f64, Ordering::Relaxed);
         }
     }
 }
@@ -22,7 +23,7 @@ impl ModifyMetric for ResettingSingleValMetric {
 impl EncodeMetric for ResettingSingleValMetric {
     fn encode(&self, mut encoder: MetricEncoder) -> Result<(), Error> {
         let current_value = self.val.load(Ordering::Relaxed);
-        encoder.encode_counter::<(), u64, u64>(&current_value, None)
+        encoder.encode_gauge::<f64>(&current_value)
     }
 
     fn metric_type(&self) -> MetricType {
@@ -31,5 +32,5 @@ impl EncodeMetric for ResettingSingleValMetric {
 }
 
 impl TypedMetric for ResettingSingleValMetric {
-    const TYPE: MetricType = MetricType::Counter;
+    const TYPE: MetricType = MetricType::Gauge;
 }


### PR DESCRIPTION
* still only returns the latest value and not acutally the peak/min/avg
* if floats are sent via UDP, the value will be rounded to an integer